### PR TITLE
tiny doc typos

### DIFF
--- a/bookmark.dtx
+++ b/bookmark.dtx
@@ -58,7 +58,7 @@
 %    use A4 as paper format:
 %       \PassOptionsToClass{a4paper}{article}
 %
-%    Programm calls to get the documentation (example):
+%    Program calls to get the documentation (example):
 %       pdflatex bookmark.dtx
 %       makeindex -s gind.ist bookmark.idx
 %       pdflatex bookmark.dtx
@@ -406,7 +406,7 @@ and the derived files
 % unhappily the file name is a secret. The package supports
 % some ways to get the file name:
 % \begin{itemize}
-% \item If \hologo{LuaTeX} (independently from DVI or PDF modus)
+% \item If \hologo{LuaTeX} (independently from DVI or PDF modes)
 %   is running, then its |status.filename| is used automatically.
 % \item Package \cs{currfile} \cite{currfile} redefines \hologo{LaTeX}
 %    internals to keep track of the file name. If the package


### PR DESCRIPTION
This just fixes two small typos in bookmark.dtx